### PR TITLE
fix: make sure jwt tokens are also generated on registration

### DIFF
--- a/WakeyWakeyBackendApi/WakeyWakeyBackendAPI/Controllers/AuthController.cs
+++ b/WakeyWakeyBackendApi/WakeyWakeyBackendAPI/Controllers/AuthController.cs
@@ -84,7 +84,8 @@ namespace WakeyWakeyBackendAPI.Controllers
             var result = new RegisterUserResponseDto()
             {
                 Name = user.Name,
-                Email = user.Email
+                Email = user.Email,
+                JwtToken = _jwtService.CreateToken(user)
             };
             return Ok(result);
 

--- a/WakeyWakeyBackendApi/WakeyWakeyBackendAPI/Dtos/AuthDtos/RegisterUserResponseDto.cs
+++ b/WakeyWakeyBackendApi/WakeyWakeyBackendAPI/Dtos/AuthDtos/RegisterUserResponseDto.cs
@@ -4,4 +4,5 @@ public class RegisterUserResponseDto
 {
     public required string Email { get; set; }
     public required string Name { get; set; }
+    public required string JwtToken { get; set; }
 }


### PR DESCRIPTION
This PR helps ensure that JWT tokens are also returned back to the frontend code upon user registration. Previously, JWT tokens were only generated on successful login.